### PR TITLE
Update JenkinsFile_MT to use new openshift build config

### DIFF
--- a/JenkinsFile_MT
+++ b/JenkinsFile_MT
@@ -32,7 +32,7 @@ node('maven') {
     
     stage('build') {
         echo "Building..."
-        openshiftBuild bldCfg: 'qsystem', showBuildLogs: 'true'
+        openshiftBuild bldCfg: 'qsystem-mt', showBuildLogs: 'true'
         openshiftTag destStream: 'qsystem', verbose: 'true', destTag: 'MT.$BUILD_ID', srcStream: 'qsystem', srcTag: 'latest'
         openshiftTag destStream: 'qsystem', verbose: 'true', destTag: 'dev-mt', srcStream: 'qsystem', srcTag: 'latest'
    }


### PR DESCRIPTION
Changed the openshiftBuild command in JenkinsFile_MT to point to the new qsystem-mt buildConfig