### PR TITLE
-Fixed issue with using the invite customer throwing an NPE

### DIFF
--- a/QSmartboard/src/java/ru/apertum/qsystem/qboard/QBoard.java
+++ b/QSmartboard/src/java/ru/apertum/qsystem/qboard/QBoard.java
@@ -263,6 +263,10 @@ public class QBoard extends GenericForwardComposer {
     }
 
     public boolean getBottomVisible() {
+        QLog.l().logQUser().debug(getPrintRecordsByOfficeId(getSessionOfficeId()).getBottomSize());
+        QLog.l().logQUser().debug( checkPlugin() ? !"".equals(getPrintRecordsByOfficeId(getSessionOfficeId()).getBottomSize().replaceAll("0|%|(px)", "")) : false);
+
+
         return checkPlugin() ? !"".equals(getPrintRecordsByOfficeId(getSessionOfficeId()).getBottomSize().replaceAll("0|%|(px)", "")) : false;
     }
 
@@ -283,7 +287,7 @@ public class QBoard extends GenericForwardComposer {
     }
     
     public String getCustomerDisplay() {
-        return checkPlugin() ? getPrintRecordsByOfficeId(1).getCustomerDisplay(): "padding:0px" ;
+        return checkPlugin() ? getPrintRecordsByOfficeId(getSessionOfficeId()).getCustomerDisplay(): "padding:0px" ;
     }   
 
     

--- a/QSmartboardPlugin/src/ru/apertum/qsystem/smartboard/PrintRecords.java
+++ b/QSmartboardPlugin/src/ru/apertum/qsystem/smartboard/PrintRecords.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.LinkedList;
 import java.util.Properties;
+
+import ru.apertum.qsystem.common.QLog;
 import ru.apertum.qsystem.server.controller.AIndicatorBoard;
 import ru.apertum.qsystem.server.model.QOffice;
 import ru.apertum.qsystem.server.model.QUser;
@@ -109,24 +111,29 @@ public class PrintRecords {
     }
     
     public PrintRecords(QOffice office) {
+        QLog.l().logQUser().debug("Creating print records");
         this.office = office;
         String qsb = "";
 
         if (office != null) {
             qsb = office.getSmartboardType();
         }
+        QLog.l().logQUser().debug("qsb: " + qsb);
 
         if (qsb != null && !qsb.isEmpty()) {
             File f = new File("config/QSmartboardPlugin.properties");
             if (qsb.equalsIgnoreCase("callbyticket")) {
+                QLog.l().logQUser().debug("getting file callbyticket");
                 f = new File("config/QSmartboardPlugin-original.properties");
             }
 
             if (qsb.equalsIgnoreCase("callbyname")) {
+                QLog.l().logQUser().debug("Getting file callbyname");
                 f = new File("config/QSmartboardPlugin-name.properties");
             }
 
             if (f.exists()) {
+                QLog.l().logQUser().debug("File exists");
                 final FileInputStream inStream;
                 try {
                     inStream = new FileInputStream(f);

--- a/QSmartboardPlugin/src/ru/apertum/qsystem/smartboard/PrintRecordsList.java
+++ b/QSmartboardPlugin/src/ru/apertum/qsystem/smartboard/PrintRecordsList.java
@@ -1,5 +1,6 @@
 package ru.apertum.qsystem.smartboard;
 
+import ru.apertum.qsystem.common.QLog;
 import ru.apertum.qsystem.server.model.QOffice;
 import ru.apertum.qsystem.server.model.QOfficeList;
 
@@ -32,6 +33,7 @@ public class PrintRecordsList extends AbstractListModel implements List {
         QOfficeList officeList = QOfficeList.getInstance();
 
         for (QOffice office: officeList.getItems()) {
+            QLog.l().logQUser().debug("Adding printRecords for office" + office);
             PrintRecords pr = new PrintRecords(office);
 
             this.printRecords.add(pr);

--- a/QSmartboardPlugin/target/classes/ru/apertum/qsystem/smartboard/PrintRecords.java
+++ b/QSmartboardPlugin/target/classes/ru/apertum/qsystem/smartboard/PrintRecords.java
@@ -23,11 +23,14 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.LinkedList;
 import java.util.Properties;
+
+import ru.apertum.qsystem.common.QLog;
 import ru.apertum.qsystem.server.controller.AIndicatorBoard;
 import ru.apertum.qsystem.server.model.QOffice;
 import ru.apertum.qsystem.server.model.QUser;
 
 /**
+ * Keeps track of the state of a smartboard for a specific office.
  *
  * @author Evgeniy Egorov
  */
@@ -108,24 +111,29 @@ public class PrintRecords {
     }
     
     public PrintRecords(QOffice office) {
+        QLog.l().logQUser().debug("Creating print records");
         this.office = office;
         String qsb = "";
 
         if (office != null) {
             qsb = office.getSmartboardType();
         }
+        QLog.l().logQUser().debug("qsb: " + qsb);
 
         if (qsb != null && !qsb.isEmpty()) {
             File f = new File("config/QSmartboardPlugin.properties");
             if (qsb.equalsIgnoreCase("callbyticket")) {
+                QLog.l().logQUser().debug("getting file callbyticket");
                 f = new File("config/QSmartboardPlugin-original.properties");
             }
 
             if (qsb.equalsIgnoreCase("callbyname")) {
+                QLog.l().logQUser().debug("Getting file callbyname");
                 f = new File("config/QSmartboardPlugin-name.properties");
             }
 
             if (f.exists()) {
+                QLog.l().logQUser().debug("File exists");
                 final FileInputStream inStream;
                 try {
                     inStream = new FileInputStream(f);

--- a/QSystem/src/ru/apertum/qsystem/client/forms/FUserChangeDialog.java
+++ b/QSystem/src/ru/apertum/qsystem/client/forms/FUserChangeDialog.java
@@ -150,7 +150,10 @@ public class FUserChangeDialog extends javax.swing.JDialog {
             }
 
             for (QService s : newOffice.getServices()) {
-                user.addPlanService(s);
+                //Only add child services, not the root or the category
+                if (s.isLeaf()) {
+                    user.addPlanService(s);
+                }
             }
         }
     }

--- a/QSystem/src/ru/apertum/qsystem/server/QServer.java
+++ b/QSystem/src/ru/apertum/qsystem/server/QServer.java
@@ -402,17 +402,18 @@ public class QServer extends Thread {
      */
     static public void loadPool() {
         QLog.l().logQUser().debug("loadPool");
-        QPostponedList.getInstance().loadPostponedList(new LinkedList<QCustomer>());
 
         final LinkedList<QCustomer> customers = new LinkedList<QCustomer>(
                 Spring.getInstance().getHt().findByCriteria(
                         DetachedCriteria.forClass(QCustomer.class)
                                 .add(Property.forName("stateIn").ne(0))
                                 .add(Property.forName("stateIn").ne(10))
+                                .add(Property.forName("stateIn").ne(11))
+                                .add(Property.forName("stateIn").ne(12))
                                 .add(Property.forName("stateIn").ne(13))
                                 .setResultTransformer((Criteria.DISTINCT_ROOT_ENTITY))));
 
-        QLog.l().logQUser().debug("adding Customers from database");
+        QLog.l().logQUser().debug("adding Customers to hold list from database");
         for (QCustomer cust : customers) {
             QLog.l().logQUser().debug("Customer: " + cust + ", " + cust.getId());
             QLog.l().logQUser().debug("serviceId: " + cust.getService().getId());
@@ -437,20 +438,20 @@ public class QServer extends Thread {
                 cust.setUser(QUserList.getInstance().getById(user.getId()));
             }
 
-            QLog.l().logQUser().debug("Adding customer to serviceTree");
             QLog.l().logQUser().debug("setPriority");
             cust.setPriority(1);
 
-            QLog.l().logQUser().debug("setState");
-            QLog.l().logQUser().debug(cust.getStateIn());
-
+            QLog.l().logQUser().debug("setState: " + cust.getStateIn());
             Integer state = cust.getStateIn();
             cust.setState(state);
 
-            cust.setState(cust.getStateIn());
+            QLog.l().logQUser().debug("Adding customer to serviceTree");
             QServiceTree.getInstance().getById(cust.getService().getId())
                     .addCustomer(cust);
         }
+
+        QLog.l().logQUser().debug("Refreshing postponed list");
+        QPostponedList.getInstance().loadPostponedList(new LinkedList<QCustomer>());
 
         return;
     }

--- a/QSystem/src/ru/apertum/qsystem/server/model/QService.java
+++ b/QSystem/src/ru/apertum/qsystem/server/model/QService.java
@@ -913,6 +913,24 @@ public class QService extends DefaultMutableTreeNode implements ITreeIdGetter, T
         return getCustomers().peek();
     }
 
+    public QCustomer peekCustomerByOffice(QOffice office) {
+        QLog.l().logQUser().debug("peekCustomerByOffice: " + office);
+        PriorityQueue<QCustomer> customers = getCustomers();
+        QCustomer customer = null;
+
+        for (Iterator<QCustomer> itr = customers.iterator(); itr.hasNext();) {
+            final QCustomer cust = itr.next();
+            QLog.l().logQUser().debug("Polling customer: " + cust);
+            QLog.l().logQUser().debug("  Office: " + cust.getOffice());
+            if (cust.getOffice().equals(office)) {
+                customer = cust;
+                break;
+            }
+        }
+
+        return customer;
+    }
+
     /**
      * Получить и удалить. может вернуть null при неудаче
      *
@@ -934,12 +952,14 @@ public class QService extends DefaultMutableTreeNode implements ITreeIdGetter, T
     }
 
     public QCustomer polCustomerByOffice(QOffice office) {
-        QLog.l().logQUser().debug("polCustomerByOffice");
+        QLog.l().logQUser().debug("polCustomerByOffice: " + office);
         PriorityQueue<QCustomer> customers = getCustomers();
         QCustomer customer = null;
 
         for (Iterator<QCustomer> itr = customers.iterator(); itr.hasNext();) {
             final QCustomer cust = itr.next();
+            QLog.l().logQUser().debug("Polling customer: " + cust);
+            QLog.l().logQUser().debug("  Office: " + cust.getOffice());
             if (cust.getOffice().equals(office)) {
                 customer = cust;
                 break;

--- a/QSystem/src/ru/apertum/qsystem/server/model/postponed/QPostponedList.java
+++ b/QSystem/src/ru/apertum/qsystem/server/model/postponed/QPostponedList.java
@@ -46,14 +46,24 @@ public class QPostponedList extends DefaultListModel {
     public QPostponedList loadPostponedList(LinkedList<QCustomer> customers) {
         QLog.l().logQUser().debug("loadPostponedList");
         clear();
-        final LinkedList<QCustomer> dbCustomers = new LinkedList<QCustomer>(
+        final LinkedList<QCustomer> dbCustomers_postponed = new LinkedList<QCustomer>(
                 Spring.getInstance().getHt().findByCriteria(
-                DetachedCriteria.forClass(QCustomer.class)
-                        .add(Property.forName("stateIn").eq(11))
-                        .add(Property.forName("stateIn").eq(12))
-                        .setResultTransformer((Criteria.DISTINCT_ROOT_ENTITY))));
+                        DetachedCriteria.forClass(QCustomer.class)
+                                .add(Property.forName("stateIn").eq(11))
+                                .setResultTransformer((Criteria.DISTINCT_ROOT_ENTITY))));
 
-        for (QCustomer cust : dbCustomers) {
+        for (QCustomer cust : dbCustomers_postponed) {
+            QLog.l().logQUser().debug("addCustomer: " + cust);
+            addElement(cust);
+        }
+
+        final LinkedList<QCustomer> dbCustomers_redirect = new LinkedList<QCustomer>(
+                Spring.getInstance().getHt().findByCriteria(
+                        DetachedCriteria.forClass(QCustomer.class)
+                                .add(Property.forName("stateIn").eq(12))
+                                .setResultTransformer((Criteria.DISTINCT_ROOT_ENTITY))));
+
+        for (QCustomer cust : dbCustomers_redirect) {
             QLog.l().logQUser().debug("addCustomer: " + cust);
             addElement(cust);
         }

--- a/QUser/src/java/ru/apertum/qsys/quser/Form.java
+++ b/QUser/src/java/ru/apertum/qsys/quser/Form.java
@@ -157,6 +157,7 @@ public class Form{
        private String checkCFMSHidden = "display: none;";
        private String checkCFMSHeight = "0%";
        private boolean checkCombo = false;
+       public String officeType;
     private QCustomer customer = null;
     @Wire("#btn_invite")
     private Button btn_invite;
@@ -293,6 +294,10 @@ public LinkedList<QService> getPreviousList(){
         if (quser != null) {
             officeName = user.getUser().getOffice().getName();
         }
+
+        QLog.l().logQUser().debug("Set attributes on login");
+        setOfficeType();
+        QLog.l().logQUser().debug("Done");
     }
 
     @Wire("#incClientDashboard #incGAManagementDialog #GAManagementDialog")
@@ -412,23 +417,51 @@ public LinkedList<QService> getPreviousList(){
         this.addWindowButtons = addWindowButtons;
     }
 
+    public String getOfficeType() {
+        return officeType;
+    }
+
+    private void setOfficeType() {
+        QLog.l().logQUser().debug("setOfficeType");
+        String receptionType = "non-reception";
+        if (getCFMSType()) {
+            receptionType = "reception";
+        }
+        QLog.l().logQUser().debug("setOfficeType: " + receptionType);
+        officeType = receptionType;
+    }
+
+    public String getCFMSTypeString() {
+        QLog.l().logQUser().debug("getCFMSTypeString");
+        String receptionType = "non-reception2";
+        if (getCFMSType()) {
+            receptionType = "reception2";
+        }
+        QLog.l().logQUser().debug("getCFMSTypeString: " + receptionType);
+        return receptionType;
+    }
+
     public boolean getCFMSType() {
         if (user == null) {
+            QLog.l().logQUser().debug("getCFMSType: User is null");
             return false;
         }
         QUser quser = user.getUser();
 
         if (quser == null) {
+            QLog.l().logQUser().debug("CFMS Type: " + false);
             return false;
         }
 
         String qsb = quser.getOffice().getSmartboardType();
+        QLog.l().logQUser().debug("qsb: " + qsb);
         if (qsb.equalsIgnoreCase("callbyticket")) {
             checkCFMSType = true;
-        };
+        }
         if (qsb.equalsIgnoreCase("callbyname")) {
             checkCFMSType = true;
-        };
+        }
+        QLog.l().logQUser().debug("CFMS Type: " + checkCFMSType);
         return checkCFMSType;
     }
 
@@ -445,39 +478,47 @@ public LinkedList<QService> getPreviousList(){
 
        public String getCFMSHidden() {
            if (user == null) {
+               QLog.l().logQUser().debug("CFMS Hidden: " + checkCFMSHidden);
                return checkCFMSHidden;
            }
            QUser quser = user.getUser();
 
            if (quser == null) {
+               QLog.l().logQUser().debug("CFMS Hidden: " + checkCFMSHidden);
                return checkCFMSHidden;
            }
            String qsb = quser.getOffice().getSmartboardType();
+           QLog.l().logQUser().debug("qsb: " + qsb);
            if (qsb.equalsIgnoreCase("callbyticket")) {
                checkCFMSHidden = "display: inline;";
-           };
+           }
            if (qsb.equalsIgnoreCase("callbyname")) {
                checkCFMSHidden = "display: inline;";
-           };
+           }
+           QLog.l().logQUser().debug("CFMS Hidden: " + checkCFMSHidden);
            return checkCFMSHidden;
        }
 
        public String getCFMSHeight() {
            if (user == null) {
+               QLog.l().logQUser().debug("CFMS Hieght: " + checkCFMSHeight);
                return checkCFMSHeight;
            }
            QUser quser = user.getUser();
 
            if (quser == null) {
+               QLog.l().logQUser().debug("CFMS Height: " + checkCFMSHeight);
                return checkCFMSHeight;
            }
            String qsb = quser.getOffice().getSmartboardType();
+           QLog.l().logQUser().debug("qsb: " + qsb);
            if (qsb.equalsIgnoreCase("callbyticket")) {
                checkCFMSHeight = "70%";
-           };
+           }
            if (qsb.equalsIgnoreCase("callbyname")) {
                checkCFMSHeight = "70%";
-           };
+           }
+           QLog.l().logQUser().debug("CFMS Height: " + checkCFMSHeight);
            return checkCFMSHeight;
        }
 
@@ -926,6 +967,7 @@ public LinkedList<QService> getPreviousList(){
     }
     
     public LinkedList<QCustomer> getPostponList() {
+        QLog.l().logger().debug("getPostponList");
         LinkedList<QCustomer> postponedCustomers = QPostponedList.getInstance().getPostponedCustomers();
         postponedCustomers = filterPostponedCustomersByUser(postponedCustomers);
         return postponedCustomers;
@@ -1091,12 +1133,16 @@ public LinkedList<QService> getPreviousList(){
 
         if (this.user != null && this.user.getUser() != null) {
             QOffice userOffice = this.user.getUser().getOffice();
+            QLog.l().logger().debug("Filtering by office: " + userOffice);
 
-            customers = customers
-                    .stream()
-                    .filter((QCustomer c) -> (c.getUser() == null ||
-                            c.getUser().getOffice().equals(userOffice)))
-                    .collect(Collectors.toCollection(LinkedList::new));
+            if (userOffice != null) {
+                customers = customers
+                        .stream()
+                        .filter((QCustomer c) -> (userOffice.equals(c.getOffice())))
+                        .collect(Collectors.toCollection(LinkedList::new));
+            }
+        } else {
+            QLog.l().logger().debug("Office is null");
         }
 
         return customers;

--- a/QUser/web/include/dialog/addTicketDialog.zul
+++ b/QUser/web/include/dialog/addTicketDialog.zul
@@ -11,7 +11,7 @@
             action="show: slideDown;hide: slideUp">
         <caption label="QSystem" image="/resources/img/logo32.png" />
         <div style="margin:10px 10px 10px 10px;">
-
+            <label value="@load(fmodel.getOfficeType())"/>
         	<zk if="${fmodel.getCFMSType()}">
 
 	            <vlayout>
@@ -80,9 +80,9 @@
 
 
 	                <div style="margin:5px 10px 10px 10px;"></div>
-	                
-	                
-	                
+
+
+
 	                <div style="float:right; margin:1px 0px 0px 0px;">
 	                    <hbox>
 
@@ -90,28 +90,28 @@
 	                    	<!-- <label value="Channels"/> -->
 	                    	 <!-- visible="@load(fmodel.addWindowButtons[0])" -->
 
-	                    
-	                    	
+
+
 
 	                        <!--Add to Queue and serve-->
 	                        <button sclass="bdd-add-to-queue" id="addToQueueBtn" hflex="min" width="100px" label="${c:l('add_to_queue')}" onClick="@command('closeAddToQueueDialog')" visible="@load(fmodel.addWindowButtons[0] and fmodel.getCFMSType())"/>
 	                        <button sclass= "bdd-begin-service" id="addAndServeBtn" hflex="min" width="100px" label="Begin service" onClick="@command('closeAddAndServeDialog')" visible="@load(fmodel.addWindowButtons[0])"/>
-	                        
+
 	                        <!--Change Service-->
 	                        <button id="OKChangeServiceBtn" hflex="min" width="100px" label="${c:l('change')}" onClick="@command('closeChangeServiceDialog')" visible="@load(fmodel.addWindowButtons[1])"/>
-	                        
+
 	                        <!--Add Next Service-->
 	                        <button sclass="bdd-apply" id="OKAddNextServiceBtn" hflex="min" width="100px" label="${c:l('apply')}" onClick="@command('closeAddNextServiceDialog')" visible="@load(fmodel.addWindowButtons[2])"/>
 
 	                        <!--Redirect / Back to Queue-->
-	                        <!--No longer exist-->                     
+	                        <!--No longer exist-->
 	                        <button id="OKredirectBtn" hflex="min" width="100px" label="${c:l('apply')}" onClick="@command('closeRedirectDialog')" visible="@load(fmodel.addWindowButtons[3])"/>
 
 	                        <!--Cancel Button For all Windows-->
 	                        <button sclass="bdd-cancel-service" id="closeAddTicketBtn" hflex="min" width="100px" label="${c:l('cancel')}" onClick="addTicketDialog.visible = false; event.stopPropagation();"/>
 	                    </hbox>
 	                </div>
-	                
+
 	            </vlayout>
 
 <!--             	<vlayout children="@load(fmodel.listServices)">
@@ -133,13 +133,13 @@
 <!-- 	                <label value="${c:l('comments')}"/>
 	                <textbox id="ticket_comments" rows="5" hflex="1" tabindex="2" value="@load( (fmodel.customer == null) ? '' : ('').concat(fmodel.customer.getTempComments()))"/> -->
 
-					
-	                	
+
+
                 		 <!-- style="float:left; margin:5px 0px 0px 0px;" -->
                 	<label value="Channels:" visible="@load(fmodel.addWindowButtons[0])"/>
 	            	    <combobox id="Channels_options" width="100%" sclass="bdd-channels-options" readonly="true" autodrop="false" hflex="1" style="" onSelect="@command('DetermineChannels')"  >
 	                		<!-- visible="@load(fmodel.addWindowButtons[0])" -->
-	                		<!-- @load(fmodel.CheckCombobox()) --> 
+	                		<!-- @load(fmodel.CheckCombobox()) -->
 	                        <attribute name="onCreate">
 	                            self.setSelectedIndex(0);
 	                        </attribute>
@@ -153,8 +153,8 @@
 	                        <!-- <comboitem label="${c:l('25min')}"/> -->
 	                        <!-- <comboitem label="${c:l('30min')}"/> -->
 	                	</combobox>
-	                	
-					
+
+
 
 	                <label value="Type Service here" width="150px" />
 	                <hbox>
@@ -168,7 +168,7 @@
 	                    </vbox>
 	                </hbox>
 	                <div style="margin:10px 10px 10px 10px;"></div>
-	                <listbox model="@load(fmodel.listServices)" selectedItem="@bind(fmodel.pickedRedirectServ)" width="100%" height="250px">			
+	                <listbox model="@load(fmodel.listServices)" selectedItem="@bind(fmodel.pickedRedirectServ)" width="100%" height="250px">
 	                <listhead>
 						<listheader label="Service" align="left" />
 						<listheader label="Category" align="left" />
@@ -179,15 +179,15 @@
 							<listcell label="@load(item.getName())" tooltip="@load(item.getId())"/>
 							<listcell label="@load(item.getParent().getName())"/>
 						</listitem>
-	                                
+
 					</template>
 				</listbox>
-	                
+
 	                <div style="margin:5px 10px 10px 10px;"></div>
 	                <label value="${c:l('comments')}"/>
                 	<textbox id="ticket_comments" rows="5" hflex="1" tabindex="2" value="@load( (fmodel.customer == null) ? '' : ('').concat(fmodel.customer.getTempComments()))"/>
-	                
-	                
+
+
 
 	                <hbox>
 


### PR DESCRIPTION
-Fixed issue with using the invite customer throwing an NPE
-Fixed issue with addServices adding categories as well as services (tree leaves)
-Fixed issue with customers in postponed list ending up in the hold list after server reboot
-Fixed issue with customers in the postponed list not being sliced by office correctly
-Fixed issue with front-end not displaying correct reception/non-reception office types
-Fixed bug with the “Currently Waiting” not displaying for call byname reception types
-Fixed bug with how the CFMS officeType is set