### PR TITLE
Add scroll bars to Serviec / Office mapping tab

### DIFF
--- a/QSystem/src/ru/apertum/qsystem/client/forms/FServiceChangeDialod.java
+++ b/QSystem/src/ru/apertum/qsystem/client/forms/FServiceChangeDialod.java
@@ -27,6 +27,7 @@ import javax.swing.ComboBoxModel;
 import javax.swing.DefaultListModel;
 import javax.swing.JComponent;
 import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.border.BevelBorder;
 import javax.swing.tree.TreeNode;
@@ -1722,7 +1723,8 @@ public class FServiceChangeDialod extends javax.swing.JDialog {
                     .addGap(18, 18, 18))
         );
 
-        jTabbedPane1.addTab("Map to Offices", jServiceOfficePanel);
+        JScrollPane panelPane = new JScrollPane(jServiceOfficePanel);
+        jTabbedPane1.addTab("Map to Offices", panelPane);
 
         checkBoxBackoffice.setText(resourceMap.getString("checkBoxBackoffice.text")); // NOI18N
         checkBoxBackoffice.setName("checkBoxBackoffice"); // NOI18N


### PR DESCRIPTION
Place the service Office Panel inside a scroll pane to ensure scroll bars are available for long office lists